### PR TITLE
Fix: Updating selectedItems based on parent updates

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -42,7 +42,7 @@
                   items: {
                     type: Array,
                     // This function is provided as part of test/utils.html, used for testing
-                    value: () => window.buildItems(10, 10, 100)
+                    value: () => window.buildItems(10, 10, 10, 10)
                   },
                   selectedItems: Array
                 },

--- a/hc-tree-node.html
+++ b/hc-tree-node.html
@@ -46,7 +46,6 @@ Custom property | Description | Default
       }
       #icon:not([visible]) {
         visibility: hidden;
-        width: 0;
 
         @apply --hc-tree-node-icon-hidden;
       }

--- a/hc-tree-view-behavior.html
+++ b/hc-tree-view-behavior.html
@@ -97,7 +97,9 @@
       item.state = state;
 
       // Change selected status for parents up the chain
-      this._updateParents(item, state);
+      const parent = this._updateParents(item, state);
+      if (parent)
+        this[parent.state === 'on' ? 'selectItems' : 'deselectItems']([parent], true);
 
       // Change selected status for children, even if they are hidden.
       this[state === 'on' ? 'selectItems' : 'deselectItems'](this._updateChildren(item, state), true);
@@ -163,6 +165,7 @@
      * @param {Object} item
      * @param {Boolean} state
      * @param {Object} [parts = this._parts]
+     * @returns {Object|undefined} Parent of the item if it exists
      */
     _updateParents(item, state, parts = this._parts) {
       // Update up the chain (parents)
@@ -180,6 +183,7 @@
           parent.state = newState;
           this._updateParents(parent, state, parts);
         }
+        return parent;
       }
     },
     /**

--- a/test/hc-nested-list_test.html
+++ b/test/hc-nested-list_test.html
@@ -35,7 +35,7 @@
         beforeEach(() => {
           // Triggers a clean build of items and parts every time.
           parts = {};
-          items = window.buildItems(count, count, count, parts);
+          items = window.buildItems(count, count, count, 0, parts);
 
           replace('iron-list').with('fake-list');
           element = fixture('basic');

--- a/test/hc-tree-view_test.html
+++ b/test/hc-tree-view_test.html
@@ -25,7 +25,7 @@
         let element, items = [], parts = {}, setSpy;
 
         beforeEach(() => {
-          items = window.buildItems(count, count, count, parts);
+          items = window.buildItems(count, count, count, 0, parts);
           element = fixture('basic');
           setSpy = sinon.spy(element, 'set');
         });

--- a/test/perf/hc-nested-list_perf.html
+++ b/test/perf/hc-nested-list_perf.html
@@ -31,7 +31,7 @@
         let parts = {}, items = [];
 
         function runTests(pSize, cSize, gcSize, modifier = 1) {
-          beforeEach(() => items = window.buildItems(pSize, cSize, gcSize, parts));
+          beforeEach(() => items = window.buildItems(pSize, cSize, gcSize, 0, parts));
 
           //_computeItems
           it('should build _items from parts in <1 frame with no parents open', () =>

--- a/test/perf/hc-tree-view_perf.html
+++ b/test/perf/hc-tree-view_perf.html
@@ -24,7 +24,7 @@
         let parts = {}, items = [];
 
         function runTests(pSize, cSize, gcSize, modifier = 1) {
-          beforeEach(() => items = window.buildItems(pSize, cSize, gcSize, parts));
+          beforeEach(() => items = window.buildItems(pSize, cSize, gcSize, 0, parts));
 
           // deselectItems
           it('should deselect an item in <1ms', () =>

--- a/test/utils.html
+++ b/test/utils.html
@@ -13,7 +13,7 @@
    * @param {Object} parts
    * @returns {Object[]}
    */
-  function buildItems(pSize, cSize, gcSize, parts = {}) {
+  function buildItems(pSize, cSize, gcSize, ggcSize = 0, parts = {}) {
     const items = [];
 
     // Add the root items
@@ -42,7 +42,7 @@
 
         // Add grand children
         for (let k = 0; k < gcSize; k++) {
-          const label = `${clabel} GrandChild ${k}`;
+          const label = `${clabel} GChild ${k}`;
           const parentId = cid;
           const id = `${cid}.${k}`;
           if (!parts[parentId]) parts[parentId] = [];
@@ -52,6 +52,20 @@
             id,
             parentId
           });
+
+          // Add great grand children
+          for (let l = 0; l < ggcSize; l++) {
+            const gclabel = `${label} GGChild ${l}`;
+            const parentId = id;
+            const gcid = `${id}.${l}`;
+            if (!parts[parentId]) parts[parentId] = [];
+
+            parts[parentId].push({
+              label: gclabel,
+              id: gcid,
+              parentId
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #30 & #31 

Updates the selectedItems based on parent updates now.
Re-add the space that was removed on nodes w/o children that were causing them to appear non-nested.

Unit Tests Added.
JSDocs Added.
Perf Tests seemed to work but computer froze occasionally.
Added another param for great grand children in the buildItems function.