### PR TITLE
Fix: Remove all items w/ id

### DIFF
--- a/hc-tree-view-behavior.html
+++ b/hc-tree-view-behavior.html
@@ -48,21 +48,23 @@
      * @param {Array.<Object>} [items = this.selectedItems]
      * @param {Boolean} [preventUpdate] - blocks the call to _updateState to block template updating
      */
-    deselectItems(items = this.selectedItems, preventUpdate) {
-      const selectedItems = Object.assign([], this.selectedItems);
-      items.forEach(item => {
-        const index = selectedItems.findIndex(i => i[this.itemIdName] === item[this.itemIdName]);
+     deselectItems(items = this.selectedItems, preventUpdate) {
+       let selectedItems = [];
 
-        // If the item exists, remove it.
-        if (index >= 0) selectedItems.splice(index, 1);
-      });
+       function getNodeId(i) {
+         return i[this.itemIdName];
+       }
+       selectedItems = this.selectedItems.map(getNodeId);
+       items = items.map(getNodeId);
 
-      // Update selectedItems if there was an item removed
-      if (this.selectedItems.length !== selectedItems.length) {
-        this.set('selectedItems', selectedItems);
-        if (!preventUpdate) this._updateState(items, 'off');
-      }
-    },
+       selectedItems = selectedItems.filter(i => items.indexOf(i) === -1);
+
+       // Update selectedItems if there was an item removed
+       if (this.selectedItems.length !== selectedItems.length) {
+         this.set('selectedItems', selectedItems);
+         if (!preventUpdate) this._updateState(items, 'off');
+       }
+     },
     /**
      * Fetches the parent for the given item.
      *

--- a/hc-tree-view-behavior.html
+++ b/hc-tree-view-behavior.html
@@ -48,23 +48,34 @@
      * @param {Array.<Object>} [items = this.selectedItems]
      * @param {Boolean} [preventUpdate] - blocks the call to _updateState to block template updating
      */
-     deselectItems(items = this.selectedItems, preventUpdate) {
-       let selectedItems = [];
+    deselectItems(items = this.selectedItems, preventUpdate) {
+      let selectedItems = [];
 
-       function getNodeId(i) {
-         return i[this.itemIdName];
-       }
-       selectedItems = this.selectedItems.map(getNodeId);
-       items = items.map(getNodeId);
+      function getNodeId(i) {
+        return i[this.itemIdName];
+      }
 
-       selectedItems = selectedItems.filter(i => items.indexOf(i) === -1);
+      // Map to Ids for perf
+      selectedItems = this.selectedItems.map(getNodeId, this);
+      passedItems = items.map(getNodeId, this);
 
-       // Update selectedItems if there was an item removed
-       if (this.selectedItems.length !== selectedItems.length) {
-         this.set('selectedItems', selectedItems);
-         if (!preventUpdate) this._updateState(items, 'off');
-       }
-     },
+      // Filter by Ids for perf
+      selectedItems = selectedItems
+        .filter(i => passedItems.indexOf(i) === -1);
+
+      // Update selectedItems if there was an item removed
+      if (this.selectedItems.length !== selectedItems.length) {
+        function getItemById(id) {
+          return this.selectedItems.find((i) => getNodeId(i) === id);
+        }
+
+      // Re-map ids to items if not empty
+       if (selectedItems.length > 0) selectedItems = selectedItems.map(getItemById, this);
+
+       this.set('selectedItems', selectedItems);
+       if (!preventUpdate) this._updateState(items, 'off');
+      }
+    },
     /**
      * Fetches the parent for the given item.
      *

--- a/test/hc-tree-view_test.html
+++ b/test/hc-tree-view_test.html
@@ -39,19 +39,19 @@
           beforeEach(() => element._updateState = sinon.spy());
 
           it('should remove all items in items from selectedItems', () => {
-            const item = {test: 'test'};
+            const item = {id: 'test'};
             element.selectedItems = [item];
             element.deselectItems([item]);
             expect(element.set.calledWithMatch('selectedItems', [])).to.equal(true);
           });
           it('should call _updateState when !preventUpdate', () => {
-            const item = {test: 'test'};
+            const item = {id: 'test'};
             element.selectedItems = [item];
             element.deselectItems([item]);
             expect(element._updateState.calledWithMatch([item], 'off')).to.equal(true);
           });
           it('should not call _updateState when preventUpdate', () => {
-            const item = {test: 'test'};
+            const item = {id: 'test'};
             element.selectedItems = [item];
             element.deselectItems([item], true);
             expect(element._updateState.called).to.equal(false);
@@ -63,14 +63,14 @@
         });
         describe('getParent(item)', () => {
           it('should call getParent on the list', () => {
-            const item = {test: 'test'};
+            const item = {id: 'test'};
             element.$.list.getParent = sinon.spy();
             element.getParent(item);
             expect(element.$.list.getParent.calledWithMatch(item)).to.equal(true);
           });
         });
         describe('itemSelectedChanged(event, detail)', () => {
-          const item = {test: 'test'};
+          const item = {id: 'test'};
           beforeEach(() => {
             element.selectItems = sinon.spy();
             element.deselectItems = sinon.spy();
@@ -98,7 +98,7 @@
             element._updateParts = sinon.spy();
             element._updateParents = sinon.spy();
             element._updateChildren = sinon.stub();
-            element._updateChildren.returns([{test: 'test'}]);
+            element._updateChildren.returns([{id: 'test'}]);
             item = items[1];
           });
 
@@ -120,13 +120,13 @@
           it('should call selectItems when state is changed to "on"', () => {
             const state = 'on';
             element.itemStateChanged(null, {item, state});
-            expect(element.selectItems.calledWithMatch([{test: 'test'}], true)).to.equal(true);
+            expect(element.selectItems.calledWithMatch([{id: 'test'}], true)).to.equal(true);
           });
           it('should call deselectItems when state is changed to !"on"', () => {
             const state = 'off';
             item.state = 'on';
             element.itemStateChanged(null, {item, state});
-            expect(element.deselectItems.calledWithMatch([{test: 'test'}], true)).to.equal(true);
+            expect(element.deselectItems.calledWithMatch([{id: 'test'}], true)).to.equal(true);
           });
           it('should debounce', () => {
             const state = 'on';


### PR DESCRIPTION
Fixed case where deselecting an item is not removing an edge case where the item and part are in selected items. This should be fixed in the refactor.

Map arrays to only be the ids and filter the ids out

Performance of deselect all is down to 5ms for 10k items.