### PR TITLE
Fix: Missing lexical this

### DIFF
--- a/hc-tree-view-behavior.html
+++ b/hc-tree-view-behavior.html
@@ -51,13 +51,11 @@
     deselectItems(items = this.selectedItems, preventUpdate) {
       let selectedItems = [];
 
-      function getNodeId(i) {
-        return i[this.itemIdName];
-      }
+      const getNodeId = (i) => i[this.itemIdName];
 
       // Map to Ids for perf
-      selectedItems = this.selectedItems.map(getNodeId, this);
-      passedItems = items.map(getNodeId, this);
+      selectedItems = this.selectedItems.map(getNodeId);
+      passedItems = items.map(getNodeId);
 
       // Filter by Ids for perf
       selectedItems = selectedItems
@@ -65,12 +63,10 @@
 
       // Update selectedItems if there was an item removed
       if (this.selectedItems.length !== selectedItems.length) {
-        function getItemById(id) {
-          return this.selectedItems.find((i) => getNodeId(i) === id);
-        }
+        const getItemById = (id) => this.selectedItems.find((i) => getNodeId(i) === id);
 
       // Re-map ids to items if not empty
-       if (selectedItems.length > 0) selectedItems = selectedItems.map(getItemById, this);
+       if (selectedItems.length > 0) selectedItems = selectedItems.map(getItemById);
 
        this.set('selectedItems', selectedItems);
        if (!preventUpdate) this._updateState(items, 'off');

--- a/test/hc-tree-view_test.html
+++ b/test/hc-tree-view_test.html
@@ -44,6 +44,13 @@
             element.deselectItems([item]);
             expect(element.set.calledWithMatch('selectedItems', [])).to.equal(true);
           });
+          it('should remove only passed items in items from selectedItems when no children associated', () => {
+            const item = {id: 'test'};
+            const item2 = {id: 'test2'};
+            element.selectedItems = [item, item2];
+            element.deselectItems([item]);
+            expect(element.set.calledWithMatch('selectedItems', [item2])).to.equal(true);
+          });
           it('should call _updateState when !preventUpdate', () => {
             const item = {id: 'test'};
             element.selectedItems = [item];


### PR DESCRIPTION
Missed a lexical `this` binding. Switched to using arrow functions to prevent having to bind to `this`.